### PR TITLE
fix: Remove optional from devcontainer mount

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -85,7 +85,7 @@
   // Mount local .env file if it exists
   "mounts": [
     "source=${localEnv:HOME}/.gemini,target=/home/node/.gemini,type=bind,consistency=cached",
-    "source=${localWorkspaceFolder}/.env,target=/workspace/.env,type=bind,consistency=cached,optional=true"
+    "source=${localWorkspaceFolder}/.env,target=/workspace/.env,type=bind,consistency=cached"
   ],
 
   // Set the default user


### PR DESCRIPTION
The 'optional' property in the mount configuration is not supported by all Docker versions, causing the dev container to fail on startup.

This commit removes the 'optional=true' from the mount configuration to ensure compatibility with a wider range of Docker versions.